### PR TITLE
feat(plugin): added ability to specify how you want the events to map…

### DIFF
--- a/.changeset/kind-owls-carry.md
+++ b/.changeset/kind-owls-carry.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/generator-eventbridge": patch
+---
+
+feat(plugin): added ability to specify how you want the events to map…

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Raise a GitHub issue on this project, or contact us on [our Discord server](http
 
 # Sponsors
 
-Thank you to our project  sponsors.
+Thank you to our project sponsors.
 
 ## Gold sponsors
 

--- a/src/test/plugin.test.ts
+++ b/src/test/plugin.test.ts
@@ -865,6 +865,26 @@ describe('EventBridge EventCatalog Plugin', () => {
       ]);
     });
 
+    it('when mapEventsBy is set to "schema-name" the schema name is used as the event id', async () => {
+      const { getEvent } = utils(catalogDir);
+
+      await plugin(config, {
+        region: 'us-east-1',
+        registryName: 'discovered-schemas',
+        services: [
+          {
+            id: 'Orders Service',
+            version: '1.0.0',
+            sends: [{ source: ['myapp.orders'] }],
+          },
+        ],
+        mapEventsBy: 'schema-name',
+      });
+
+      const versionedEvent = await getEvent('myapp.orders@OrderPlaced', '10');
+      expect(versionedEvent).toBeDefined();
+    });
+
     describe('events without services', () => {
       it('if no services or domains are provided all the messages are added to EventCatalog without a service', async () => {
         const { getEvent } = utils(catalogDir);

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,8 @@ export type Service = {
   version: string;
 };
 
+export type EventMap = 'detail-type' | 'schema-name';
+
 export type GeneratorProps = {
   region: string;
   registryName: string;
@@ -47,5 +49,6 @@ export type GeneratorProps = {
   services?: Service[];
   domain?: Domain;
   debug?: boolean;
+  mapEventsBy?: EventMap;
   credentials?: AwsCredentialIdentity | AwsCredentialIdentityProvider;
 };


### PR DESCRIPTION
This introduces a new generator field called `mapEventsBy` by default the plugin continues to map by detailType, but if you set the value to `schema-name` the schema name "source@detailType" is used.